### PR TITLE
Explicitly specify license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevier"
 version = "1.1.1"
 edition = "2021"
-license-file = "LICENSE"
+license = "MIT"
 description = "An interactive CLI to generate Games using the Bevy Game Engine."
 repository = "https://github.com/DraftedDev/bevier"
 keywords = ["gamedev", "cli", "bevy", "generate"]


### PR DESCRIPTION
In the [docs for the Cargo manifest format](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields), the use of `license-file` is only recommended for non-standard licenses. For standard licenses such as MIT, it should be specified in the `license` field explicitly.

This change makes it easier for tools to correctly identify the license. For example, right now the license is identified as `non-standard` on both [crates.io](https://crates.io/crates/bevier) and the [Bevy Assets page](https://bevyengine.org/assets/#templates).